### PR TITLE
Fix threads undefined error

### DIFF
--- a/src/Post.js
+++ b/src/Post.js
@@ -20,7 +20,7 @@ export default function Post() {
         // Fetch threads when component mounts
         axios.get(`${process.env.REACT_APP_API_URL}/threads`)
             .then((response) => {
-                setThreads(response.data.threads);
+                setThreads(response.data.threads || []);
             })
             .catch((error) => console.error("There was an error fetching the threads:", error));
     }, []);

--- a/src/Threads.js
+++ b/src/Threads.js
@@ -9,7 +9,7 @@ export default function Threads({ onSelectThread }) {
   useEffect(() => {
     axios
       .get(`${process.env.REACT_APP_API_URL}/threads`)
-      .then((res) => setData(res.data.threads))
+      .then((res) => setData(res.data.threads || []))
       .catch(console.error);
   }, []);
 


### PR DESCRIPTION
## Summary
- safeguard thread list fetches when API returns no data

## Testing
- `npm test --silent --maxWorkers=50` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545dc1856483299ed713201b93b962